### PR TITLE
MRC-683: Allow unlimited file size upload

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -25,6 +25,12 @@ http {
 
     keepalive_timeout  65;
 
+    # this sets the maximum size information to be unlimited; it might
+    # be better to set this to apply only to authenticated endpoints
+    # (once people are authenticated I think we can allow them to send
+    # things of unlimited size).
+    client_max_body_size 0;
+
     # Main server configuration. See below for redirects.
     server {
         listen       ${HTTPS_PORT} ssl;


### PR DESCRIPTION
This PR will allow uploads of unlimited file size through the proxy. This is the same configuration as used in montagu-proxy (see [here](https://github.com/vimc/montagu-proxy/blob/e2bce378de9518667e109d25de5e66ac363e1b09/nginx.conf#L28-L32))

This exposes us to a possible DOS but it's not the only thing we'd need to fix on that.

Currently deployed on the staging hint as https://naomi.dide.ic.ac.uk:10443