### PR TITLE
Mrc 1628

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.15
+FROM nginx:stable
 
 # Only used for generating self-signed certificates
 RUN apt-get update && apt-get install -y openssl

--- a/nginx.conf
+++ b/nginx.conf
@@ -54,7 +54,7 @@ http {
         # > using HTTPS. Even if the user enters or follows a plain
         # > HTTP link, the browser strictly upgrades the connection to
         # > HTTPS:
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        # add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
         # https://content-security-policy.com/
         add_header Content-Security-Policy "default-src 'self';";

--- a/nginx.conf
+++ b/nginx.conf
@@ -42,7 +42,7 @@ http {
 
         # SSL settings as recommended by this blog:
         # https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
-        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+        ssl_protocols TLSv1.2 TLSv1.3;
         ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
         ssl_prefer_server_ciphers on;
         ssl_session_cache shared:SSL:10m;

--- a/nginx.conf
+++ b/nginx.conf
@@ -48,6 +48,40 @@ http {
         ssl_session_cache shared:SSL:10m;
         ssl_dhparam /run/proxy/dhparam.pem;
 
+        # https://www.nginx.com/blog/http-strict-transport-security-hsts-and-nginx/
+        # > HSTS seeks to deal with the potential vulnerability by
+        # > instructing the browser that a domain can only be accessed
+        # > using HTTPS. Even if the user enters or follows a plain
+        # > HTTP link, the browser strictly upgrades the connection to
+        # > HTTPS:
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+        # https://content-security-policy.com/
+        add_header Content-Security-Policy "default-src 'self';";
+
+        # config to don't allow the browser to render the page inside
+        # an frame or iframe and avoid click jacking
+        # http://en.wikipedia.org/wiki/Clickjacking if you need to
+        # allow [i]frames, you can use SAMEORIGIN or even set an uri
+        # with ALLOW-FROM uri
+        # https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options
+        add_header X-Frame-Options SAMEORIGIN;
+
+        # when serving user-supplied content, include a
+        # X-Content-Type-Options: nosniff header along with the
+        # Content-Type: header, to disable content-type sniffing on
+        # some browsers.
+        # https://www.owasp.org/index.php/List_of_useful_HTTP_headers
+        # currently suppoorted in IE > 8
+        # http://blogs.msdn.com/b/ie/archive/2008/09/02/ie8-security-part-vi-beta-2-update.aspx
+        # http://msdn.microsoft.com/en-us/library/ie/gg622941(v=vs.85).aspx
+        # 'soon' on Firefox
+        # https://bugzilla.mozilla.org/show_bug.cgi?id=471020
+        add_header X-Content-Type-Options nosniff;
+
+        # https://scotthelme.co.uk/a-new-security-header-referrer-policy/
+        add_header Referrer-Policy strict-origin;
+
         root /usr/share/nginx/html;
 
         location / {


### PR DESCRIPTION
As reported by ICT this tightens up the nginx proxy following this problem report:

* https://securityheaders.com/?q=https%3A%2F%2Fnaomi.unaids.org%2F&hide=on
* https://www.ssllabs.com/ssltest/analyze.html?d=naomi.unaids.org&hideResults=on

I have

* Disabled TLS v1.0 and v1.1 and enabled v1.3
* Added most of the extra headers except for "feature-policy" - but would do so if I could understand what it should say! https://scotthelme.co.uk/a-new-security-header-feature-policy/
* Upgraded nginx to track "stable" which seems fair